### PR TITLE
Updating tests for Xcode7.3

### DIFF
--- a/analytics-testingTests/LoginViewModelTests.swift
+++ b/analytics-testingTests/LoginViewModelTests.swift
@@ -43,7 +43,7 @@ class LoginViewModelTests: XCTestCase {
     
     // MARK: - Helpers
     
-    func verifyScreenViewAnalytics(screen: String, when block:(()->Void), line: UInt = __LINE__, file: String = __FILE__) {
+    func verifyScreenViewAnalytics(screen: String, when block:(()->Void), line: UInt = #line, file: StaticString = #file) {
         
         // setup expectations
         let e = expectationWithDescription("screen view analytics should be logged")
@@ -63,7 +63,7 @@ class LoginViewModelTests: XCTestCase {
         }
     }
     
-    func verifyEventAnalytics(event: String, action: String, when block:(()->Void), line: UInt = __LINE__, file: String = __FILE__) {
+    func verifyEventAnalytics(event: String, action: String, when block:(()->Void), line: UInt = #line, file: StaticString = #file) {
         
         // setup expectations
         let e = expectationWithDescription("screen view analytics should be logged")

--- a/analytics-testingUITests/AnalyticsTester.swift
+++ b/analytics-testingUITests/AnalyticsTester.swift
@@ -29,39 +29,39 @@ class AnalyticsTester {
     }
     
     func verify(count count: Int,
-        line: UInt = __LINE__,
-        file: String = __FILE__) {
+        line: UInt = #line,
+        file: StaticString = #file) {
             let records = extractAnalytics()
             XCTAssertEqual(records.count, count, line: line, file: file)
     }
     
     func verify(type occurrence: ItemOccurrence<AnalyticsRecordType>,
-        line: UInt = __LINE__,
-        file: String = __FILE__) {
+        line: UInt = #line,
+        file: StaticString = #file) {
             let records = extractAnalytics()
             let matchingRecords = records.filter{$0.type.rawValue == occurrence.item.rawValue}
             XCTAssertEqual(matchingRecords.count, occurrence.occurs, line: line, file: file)
     }
     
     func verify(id occurrence: ItemOccurrence<String>,
-        line: UInt = __LINE__,
-        file: String = __FILE__) {
+        line: UInt = #line,
+        file: StaticString = #file) {
             let records = extractAnalytics()
             let matchingRecords = records.filter{$0.identifier == occurrence.item}
             XCTAssertEqual(matchingRecords.count, occurrence.occurs, line: line, file: file)
     }
     
     func verify(data occurrence: ItemOccurrence<String>,
-        line: UInt = __LINE__,
-        file: String = __FILE__) {
+        line: UInt = #line,
+        file: StaticString = #file) {
             let records = extractAnalytics()
             let matchingRecords = records.filter{$0.data == occurrence.item}
             XCTAssertEqual(matchingRecords.count, occurrence.occurs, line: line, file: file)
     }
     
     func verify(idAndData occurrence: ItemOccurrence<(id: String, data: String)>,
-        line: UInt = __LINE__,
-        file: String = __FILE__) {
+        line: UInt = #line,
+        file: StaticString = #file) {
             let records = extractAnalytics()
             let matchingRecords = records.filter{ $0.identifier == occurrence.item.id && $0.data == occurrence.item.data}
             XCTAssertEqual(matchingRecords.count, occurrence.occurs, line: line, file: file)


### PR DESCRIPTION
- Updated `xctest` helper methods to use `#line` and `#file` instead of `__LINE__` and `__FILE__`
- Updated `xctest` helper methods to use `StaticString` as the type for `#file`
